### PR TITLE
chore: rename to binary-dependencies-manager

### DIFF
--- a/.github/workflows/scripts/build-multi-platform-binary/build-binary.sh
+++ b/.github/workflows/scripts/build-multi-platform-binary/build-binary.sh
@@ -4,10 +4,10 @@ set -e
 
 # Extract version from tag (remove 'v' prefix if present)
 VERSION=${TAG_NAME#v}
-BINARY_NAME="BinaryDependenciesManager"
+BINARY_NAME="binary-dependencies-manager"
 PLATFORM=${PLATFORM:-macOS}
 ARCH=${ARCH:-universal}
-ARCHIVE_NAME="BinaryDependenciesManager-${PLATFORM}-${ARCH}-${VERSION}.zip"
+ARCHIVE_NAME="${BINARY_NAME}-${VERSION}-${PLATFORM}-${ARCH}.zip"
 
 echo "Building binary for platform: $PLATFORM, architecture: $ARCH, version: $VERSION"
 

--- a/.github/workflows/scripts/build-multi-platform-binary/check-asset.js
+++ b/.github/workflows/scripts/build-multi-platform-binary/check-asset.js
@@ -26,7 +26,7 @@ async function checkAsset() {
 
   // Extract version from tag (remove 'v' prefix if present)
   const version = tagName.replace(/^v/, '');
-  const expectedAssetName = `BinaryDependenciesManager-${version}-${platform}-${arch}.zip`;
+  const expectedAssetName = `binary-dependencies-manager-${version}-${platform}-${arch}.zip`;
 
   console.log(`Checking for asset: ${expectedAssetName} in release ${releaseId}`);
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,18 +5,18 @@
             "request": "launch",
             "args": [],
             "cwd": "${workspaceFolder:binary-dependencies-manager}",
-            "name": "Debug BinaryDependenciesManager",
-            "program": "${workspaceFolder:binary-dependencies-manager}/.build/debug/BinaryDependenciesManager",
-            "preLaunchTask": "swift: Build Debug BinaryDependenciesManager"
+            "name": "Debug binary-dependencies-manager",
+            "program": "${workspaceFolder:binary-dependencies-manager}/.build/debug/binary-dependencies-manager",
+            "preLaunchTask": "swift: Build Debug binary-dependencies-manager"
         },
         {
             "type": "swift",
             "request": "launch",
             "args": [],
             "cwd": "${workspaceFolder:binary-dependencies-manager}",
-            "name": "Release BinaryDependenciesManager",
-            "program": "${workspaceFolder:binary-dependencies-manager}/.build/release/BinaryDependenciesManager",
-            "preLaunchTask": "swift: Build Release BinaryDependenciesManager"
+            "name": "Release binary-dependencies-manager",
+            "program": "${workspaceFolder:binary-dependencies-manager}/.build/release/binary-dependencies-manager",
+            "preLaunchTask": "swift: Build Release binary-dependencies-manager"
         }
     ]
 }

--- a/Package.swift
+++ b/Package.swift
@@ -4,14 +4,14 @@
 import PackageDescription
 
 let package = Package(
-    name: "BinaryDependenciesManager",
+    name: "binary-dependencies-manager",
     platforms: [
         .macOS(.v11),
     ],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.
         .executable(
-            name: "BinaryDependenciesManager",
+            name: "binary-dependencies-manager",
             targets: ["BinaryDependenciesManager"]
         ),
     ],

--- a/compile_and_update_binary.sh
+++ b/compile_and_update_binary.sh
@@ -1,5 +1,5 @@
 # Build the Swift package in release mode for both x86_64 and arm64 architectures
 swift build -c release --arch x86_64 --arch arm64
 
-# Copy the built BinaryDependenciesManager binary to the Binary directory
-cp .build/apple/Products/Release/BinaryDependenciesManager ./Binary/BinaryDependenciesManager
+# Copy the built binary-dependencies-manager binary to the Binary directory
+cp .build/apple/Products/Release/binary-dependencies-manager ./Binary/binary-dependencies-manager


### PR DESCRIPTION
# Pull Request Template

## Description
Rename binary to the binary-dependencies-manager.
This reduces the tool configuration for mise from 
    `"ubi:MacPaw/binary-dependencies-manager" = { version = "latest", exe = "BinaryDependenciesManager"}` 
    to just 
    `"ubi:MacPaw/binary-dependencies-manager" = "latest"`.

Because the default binary name is the GitHub repo basename.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

## Additional Context
Add any other context or screenshots about the pull request here. 