### PR TITLE
fix: resolve command

### DIFF
--- a/Sources/CommandLine/Commands/ResolveCommand.swift
+++ b/Sources/CommandLine/Commands/ResolveCommand.swift
@@ -17,7 +17,7 @@ struct ResolveCommand: ParsableCommand {
     /// $ binary-dependencies-manager resolve --config ./.binary-dependencies.yaml
     /// $ binary-dependencies-manager resolve -c ./.binary-dependencies.yaml
     /// ```
-    @Option(name: [.customLong("config", withSingleDash: true), .short], help: "Path to the configuration file")
+    @Option(name: [.customLong("config"), .short], help: "Path to the configuration file")
     var configurationFilePath: String?
 
     /// Path to the output directory.


### PR DESCRIPTION
# Pull Request Template

## Description
Fix resolve long name for the `config` parameter. Was `-config` (no second dash), now it's `--config`.

I do hate copy-paste errors.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

## Additional Context
Add any other context or screenshots about the pull request here. 