### PR TITLE
chore: add copyItem to FileManagerProtocol

### DIFF
--- a/Sources/BinaryDependencyManager/Utils/FileManagerProtocol.swift
+++ b/Sources/BinaryDependencyManager/Utils/FileManagerProtocol.swift
@@ -27,6 +27,8 @@ public protocol FileManagerProtocol {
     func contentsOfDirectory(atPath path: String) throws -> [String]
 
     func createFile(atPath path: String, contents data: Data?, attributes attr: [FileAttributeKey : Any]?) -> Bool
+
+    func copyItem(at srcURL: URL, to dstURL: URL) throws
 }
 
 extension FileManagerProtocol {

--- a/Tests/BinaryDependencyManagerTests/Mocks/FileManagerProtocolMock.swift
+++ b/Tests/BinaryDependencyManagerTests/Mocks/FileManagerProtocolMock.swift
@@ -2,12 +2,20 @@
 import Foundation
 
 class FileManagerProtocolMock: FileManagerProtocol {
+    var copiedFiles: [URL: URL] = [:]
+    func copyItem(at srcURL: URL, to dstURL: URL) throws {
+        copiedFiles[srcURL] = dstURL
+        existingFiles.insert(dstURL.filePath)
+        contentsMap[dstURL] = contentsMap[srcURL]
+    }
+
     func createDirectory(at url: URL, withIntermediateDirectories createIntermediates: Bool, attributes: [FileAttributeKey : Any]?) throws {
         createdDirectories.append(url)
     }
 
+    var directoryContents: [String: [String]] = [:]
     func contentsOfDirectory(atPath path: String) throws -> [String] {
-        []
+        directoryContents[path] ?? []
     }
 
     var existingFiles: Set<String> = []
@@ -31,7 +39,11 @@ class FileManagerProtocolMock: FileManagerProtocol {
 
     var temporaryDirectory: URL { tempDir }
     func contents(at url: URL) -> Data? { contentsMap[url] }
-    func removeItem(at url: URL) throws { removedItems.append(url) }
+    func removeItem(at url: URL) throws {
+        removedItems.append(url)
+        existingFiles.remove(url.filePath)
+        contentsMap[url] = .none
+    }
 
     var createdFiles: [String] = []
     func createFile(atPath path: String, contents data: Data?, attributes attr: [FileAttributeKey : Any]?) -> Bool {


### PR DESCRIPTION
# Pull Request Template

## Description
Add missing `copyItem` method to the FileManagerProtocol. This will allow to test the `unzip` method in the runner. 

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

## Additional Context
Add any other context or screenshots about the pull request here. 