### PR TITLE
chore: standartize file URLs and update tests

### DIFF
--- a/Sources/BinaryDependencyManager/DepeneciesResolverRunner.swift
+++ b/Sources/BinaryDependencyManager/DepeneciesResolverRunner.swift
@@ -135,7 +135,7 @@ public struct DependenciesResolverRunner {
         try unarchiver.unzip(archivePath: downloadedFileURL.path(percentEncoded: false), outputFilePath: tempDir.path(percentEncoded: false))
 
         // if we have additional contents directory from dependency, we should use it
-        let contentsDirectoryURL = tempDir.appending(path: asset.contents ?? "", directoryHint: .isDirectory)
+        let contentsDirectoryURL = tempDir.appending(path: asset.contents ?? "", directoryHint: .isDirectory).standardizedFileURL
 
         let contents = try fileManager.contentsOfDirectory(at: contentsDirectoryURL)
 
@@ -183,6 +183,7 @@ public struct DependenciesResolverRunner {
     func downloadDirectoryURL(for dependency: Dependency, asset: Dependency.Asset) -> URL {
         downloadsDirectoryURL
             .appending(components: dependency.repo, dependency.tag, asset.outputDirectory ?? "", directoryHint: .isDirectory)
+            .standardizedFileURL
     }
     
     /// Location of the file where the downloaded dependency will be placed
@@ -194,6 +195,7 @@ public struct DependenciesResolverRunner {
     func outputDirectoryURL(for dependency: Dependency, asset: Dependency.Asset) -> URL {
         outputDirectoryURL
             .appending(components: dependency.repo, asset.outputDirectory ?? "", directoryHint: .isDirectory)
+            .standardizedFileURL
     }
 
     func outputDirectoryHashFile(for dependency: Dependency, asset: Dependency.Asset) throws -> URL {

--- a/Tests/BinaryDependencyManagerTests/DependenciesResolverRunner/DependenciesResolverRunnerFileURLTests.swift
+++ b/Tests/BinaryDependencyManagerTests/DependenciesResolverRunner/DependenciesResolverRunnerFileURLTests.swift
@@ -19,7 +19,7 @@ extension DependenciesResolverRunnerTests {
         #expect(downloadsDir.path(percentEncoded: false).hasSuffix("/\(relativePath)/.downloads/"))
         #expect(
             downloadsDir == FileManager.default.currentDirectoryPath.asFileURL
-                .appending(components: relativePath, ".downloads", directoryHint: .isDirectory)
+                .appending(path: "relative/cache/.downloads", directoryHint: .isDirectory)
         )
     }
 
@@ -51,11 +51,9 @@ extension DependenciesResolverRunnerTests {
         #expect(
             outputDir == FileManager.default.currentDirectoryPath.asFileURL
                 .appending(
-                    components: relativePath,
-                    sampleDependency.repo,
-                    sampleAsset.outputDirectory ?? "",
+                    components: "relative/output/org/repo", sampleAsset.outputDirectory ?? "",
                     directoryHint: .isDirectory
-                )
+                ).standardizedFileURL
         )
     }
 
@@ -70,9 +68,9 @@ extension DependenciesResolverRunnerTests {
         // THEN
         #expect(
             downloadURL == tempDir.appending(
-                components: "cache/.downloads", sampleDependency.repo, sampleDependency.tag, sampleAsset.outputDirectory ?? "", sampleAsset.checksum + ".zip",
+                path: "cache/.downloads/org/repo/1.0.0/abc123.zip",
                 directoryHint: .notDirectory
-            )
+            ).standardizedFileURL
         )
     }
 
@@ -85,10 +83,9 @@ extension DependenciesResolverRunnerTests {
         let hashURL = try runner.outputDirectoryHashFile(for: sampleDependency, asset: sampleAsset)
 
         // THEN
-        let hashFilename = "." + (sampleAsset.pattern?.replacingOccurrences(of: ".", with: "_") ?? "") + ".hash"
         #expect(
             hashURL == tempDir.appending(
-                components: "output", sampleDependency.repo, sampleAsset.outputDirectory ?? "", hashFilename,
+                path: "output/org/repo/.asset_zip.hash",
                 directoryHint: .notDirectory
             )
         )

--- a/Tests/BinaryDependencyManagerTests/DependenciesResolverRunner/DependenciesResolverRunnerUnzipTests.swift
+++ b/Tests/BinaryDependencyManagerTests/DependenciesResolverRunner/DependenciesResolverRunnerUnzipTests.swift
@@ -187,7 +187,7 @@ final class DependenciesResolverRunnerUnzipTests {
         let tempRootDir = tempDir.appending(
             components: "PrivateDownloads", "mock-uuid", assetWithoutContents.contents ?? "",
             directoryHint: .isDirectory
-        )
+        ).standardizedFileURL
         fileManager.directoryContents = [
             tempRootDir.path(percentEncoded: false): ["file1.txt", "file2.txt"]
         ]


### PR DESCRIPTION
# Pull Request Template

## Description
Use exact strings for file location tests.

When dealing with `url.appending(components: "")` (optional asset output path), Swift adds an extra `/` in the end. We need to use `.standardizedFileURL` for those cases to remove double `/` in path.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

## Additional Context
Add any other context or screenshots about the pull request here. 