### PR TITLE
chore(ci): revert to swift-tools-version 5.10

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,7 @@
-// swift-tools-version: 6.1
+// swift-tools-version: 5.10
 // The swift-tools-version declares the minimum version of Swift required to build this package.
+//
+// Not using 6.1 because CodeQL default runner is not ubuntu-latest and doesn't support it yet (Checked: 2025-07-03).
 
 import PackageDescription
 
@@ -62,7 +64,8 @@ let package = Package(
         ),
     ],
 
-    swiftLanguageModes: [
-        .v6
+    swiftLanguageVersions: [
+        .v5,
+        .version("6") // swift-tools 5.10 has no .v6 enum case yet.
     ]
 )


### PR DESCRIPTION
# Pull Request Template

## Description

The default CodeQL runner doesn't support Swift 6. Which is extremely sad.

I suggest lowering the swift-tools version to 5.10 and trying it out, because I want to avoid supporting a custom CodeQL workflow at this moment. It could be a future improvement, but right now I want to focus on passing checks and having zero warnings.

Problem with CodeQL: https://github.com/MacPaw/binary-dependencies-manager/actions/runs/16051019533/job/45293437166

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Other (please describe): CI, CodeQL

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

## Additional Context
Add any other context or screenshots about the pull request here. 