### PR TITLE
fix: show asset pattern and output directory in the dependencies listing

### DIFF
--- a/Sources/BinaryDependencyManager/Utils/BinaryDependenciesConfigurationReader.swift
+++ b/Sources/BinaryDependencyManager/Utils/BinaryDependenciesConfigurationReader.swift
@@ -108,13 +108,31 @@ public struct BinaryDependenciesConfigurationReader {
 
         let dependencies = configuration.dependencies
         let dependenciesInfo = dependencies
-            .map { "   \($0.repo)(\($0.tag))" }
+            .flatMap { dependency in
+                dependency.assets.map { "   \(info(for: dependency, asset: $0))" }
+            }
             .joined(separator: "\n")
         Logger.log(
             "[Read] Found \(dependencies.count) dependencies:\n\(dependenciesInfo)"
         )
 
         return configuration
+    }
+
+    /// Builds a single-line description of a dependency asset, e.g. `owner/repo(1.0.0) Asset.zip -> output/dir`.
+    /// - Parameters:
+    ///   - dependency: The dependency the asset belongs to.
+    ///   - asset: The asset to describe.
+    /// - Returns: A string with the repo, tag, asset pattern (or contents), and output directory when present.
+    func info(for dependency: Dependency, asset: Dependency.Asset) -> String {
+        var components: [String] = ["\(dependency.repo)(\(dependency.tag))"]
+        if let pattern = asset.pattern ?? asset.contents {
+            components.append(pattern)
+        }
+        if let outputDirectory = asset.outputDirectory {
+            components.append("-> \(outputDirectory)")
+        }
+        return components.joined(separator: " ")
     }
 }
 

--- a/Tests/BinaryDependencyManagerTests/BinaryDependenciesConfigurationReaderTests.swift
+++ b/Tests/BinaryDependencyManagerTests/BinaryDependenciesConfigurationReaderTests.swift
@@ -81,5 +81,29 @@ final class BinaryDependenciesConfigurationReaderTests: XCTestCase {
         )
         XCTAssertEqual(config, expected)
     }
+
+    func test_info_withPattern() {
+        let sut = makeReader(withFiles: [])
+        let dependency = Dependency(repo: "test/repo", tag: "1.0.0", assets: [])
+        let asset = Dependency.Asset(checksum: "check1", pattern: "Asset.xcframework.zip")
+
+        XCTAssertEqual(sut.info(for: dependency, asset: asset), "test/repo(1.0.0) Asset.xcframework.zip")
+    }
+
+    func test_info_withPatternAndOutputDirectory() {
+        let sut = makeReader(withFiles: [])
+        let dependency = Dependency(repo: "test/repo", tag: "1.0.0", assets: [])
+        let asset = Dependency.Asset(checksum: "check1", pattern: "Asset.framework.zip", outputDirectory: "sandbox")
+
+        XCTAssertEqual(sut.info(for: dependency, asset: asset), "test/repo(1.0.0) Asset.framework.zip -> sandbox")
+    }
+
+    func test_info_withoutPattern_fallsBackToContents() {
+        let sut = makeReader(withFiles: [])
+        let dependency = Dependency(repo: "test/repo", tag: "1.0.0", assets: [])
+        let asset = Dependency.Asset(checksum: "check1", contents: "Products")
+
+        XCTAssertEqual(sut.info(for: dependency, asset: asset), "test/repo(1.0.0) Products")
+    }
 }
 


### PR DESCRIPTION
## Description
The `[Read]` dependencies listing printed one `repo(tag)` line per manifest entry. When a repo has multiple entries with different asset `pattern`s (or different `output` directories), the output was a wall of identical lines that said nothing about what is actually being installed.

Each listed line now includes the asset `pattern` (falling back to `contents` when there is no pattern) and the `output` directory when the entry has one.

**Before:**
```
[Read] Found 4 dependencies:
   owner/multi-asset-repo(1.2.3)
   owner/multi-asset-repo(1.2.3)
   owner/framework(2.0.0)
   owner/framework(2.0.0)
```

**After:**
```
[Read] Found 4 dependencies:
   owner/multi-asset-repo(1.2.3) FirstAsset.xcframework.zip
   owner/multi-asset-repo(1.2.3) SecondAsset.xcframework.zip
   owner/framework(2.0.0) Framework.zip -> sandbox
   owner/framework(2.0.0) Framework.zip -> nonsandbox
```

The listing also emits one line per asset for dependencies that use the nested `assets:` form, instead of one line per dependency.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Context
Verified with `swift build && swift test` (all tests pass) and a real `resolve` run against a consumer manifest in a scratch directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
